### PR TITLE
Add initializer to test.py and ask

### DIFF
--- a/training/src/test.py
+++ b/training/src/test.py
@@ -130,6 +130,8 @@ def run_with_frozen_pb(img_path, input_w_h, frozen_graph, output_node_names):
     image_ = cv2.resize(image_0, (input_w_h, input_w_h), interpolation=cv2.INTER_AREA)
 
     with tf.Session() as sess:
+        sess.run(tf.global_variables_initializer())
+
         heatmaps = sess.run(output, feed_dict={image: [image_]})
         CocoPose.display_image(
             # np.reshape(image_, [1, input_w_h, input_w_h, 3]),


### PR DESCRIPTION
I'm trying to run `test.py` for validating a model(`model-14000.pb`). But there is some error.
```
FailedPreconditionError (see above for traceback): Attempting to use uninitialized value Conv2d_0/weights
	 [[Node: Conv2d_0/weights/read = Identity[T=DT_FLOAT, _device="/job:localhost/replica:0/task:0/device:CPU:0"](Conv2d_0/weights)]]
```
I think above msg is a hint. There are weights not initialized. So I make PR for this.

But something is confusing me.
1. At line 117, is already `tf.import_graph_def()` initialize variables?
2. If I initialize variables(`sess.run(tf.global_variables_initializer())`), all variable is made not trained state?

#### Full error.
```
Traceback (most recent call last):
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1322, in _do_call
    return fn(*args)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1307, in _run_fn
    options, feed_dict, fetch_list, target_list, run_metadata)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1409, in _call_tf_sessionrun
    run_metadata)
tensorflow.python.framework.errors_impl.FailedPreconditionError: Attempting to use uninitialized value Conv2d_0/weights
	 [[Node: Conv2d_0/weights/read = Identity[T=DT_FLOAT, _device="/job:localhost/replica:0/task:0/device:CPU:0"](Conv2d_0/weights)]]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "src/test.py", line 166, in <module>
    "Convolutional_Pose_Machine/stage_5_out"
  File "src/test.py", line 135, in run_with_frozen_pb
    heatmaps = sess.run(output, feed_dict={image: [image_]})
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 900, in run
    run_metadata_ptr)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1135, in _run
    feed_dict_tensor, options, run_metadata)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1316, in _do_run
    run_metadata)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1335, in _do_call
    raise type(e)(node_def, op, message)
tensorflow.python.framework.errors_impl.FailedPreconditionError: Attempting to use uninitialized value Conv2d_0/weights
	 [[Node: Conv2d_0/weights/read = Identity[T=DT_FLOAT, _device="/job:localhost/replica:0/task:0/device:CPU:0"](Conv2d_0/weights)]]

Caused by op 'Conv2d_0/weights/read', defined at:
  File "src/test.py", line 153, in <module>
    metric_prefix(256, 256)
  File "src/test.py", line 91, in metric_prefix
    get_network("mv2_cpm_fingertip", input_node, False)
  File "/Users/canapio/Project/Just-Point/ML-project/tucan9389:PoseEstimationForMobile/training/src/networks.py", line 11, in get_network
    net, loss = network_mv2_cpm.build_network(input, trainable)
  File "/Users/canapio/Project/Just-Point/ML-project/tucan9389:PoseEstimationForMobile/training/src/network_mv2_cpm.py", line 32, in build_network
    net = convb(input, 3, 3, out_channel_ratio(32), 2, name="Conv2d_0")
  File "/Users/canapio/Project/Just-Point/ML-project/tucan9389:PoseEstimationForMobile/training/src/network_base.py", line 127, in convb
    trainable=_trainable)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/contrib/framework/python/ops/arg_scope.py", line 183, in func_with_args
    return func(*args, **current_args)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/contrib/layers/python/layers/layers.py", line 1049, in convolution
    outputs = layer.apply(inputs)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/layers/base.py", line 828, in apply
    return self.__call__(inputs, *args, **kwargs)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/layers/base.py", line 699, in __call__
    self.build(input_shapes)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/layers/convolutional.py", line 144, in build
    dtype=self.dtype)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/layers/base.py", line 546, in add_variable
    partitioner=partitioner)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/training/checkpointable.py", line 436, in _add_variable_with_custom_getter
    **kwargs_for_getter)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 1317, in get_variable
    constraint=constraint)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 1079, in get_variable
    constraint=constraint)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 417, in get_variable
    return custom_getter(**custom_getter_kwargs)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/contrib/layers/python/layers/layers.py", line 1611, in layer_variable_getter
    return _model_variable_getter(getter, *args, **kwargs)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/contrib/layers/python/layers/layers.py", line 1602, in _model_variable_getter
    use_resource=use_resource)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/contrib/framework/python/ops/arg_scope.py", line 183, in func_with_args
    return func(*args, **current_args)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/contrib/framework/python/ops/variables.py", line 291, in model_variable
    use_resource=use_resource)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/contrib/framework/python/ops/arg_scope.py", line 183, in func_with_args
    return func(*args, **current_args)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/contrib/framework/python/ops/variables.py", line 246, in variable
    use_resource=use_resource)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 394, in _true_getter
    use_resource=use_resource, constraint=constraint)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 786, in _get_single_variable
    use_resource=use_resource)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 2220, in variable
    use_resource=use_resource)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 2210, in <lambda>
    previous_getter = lambda **kwargs: default_variable_creator(None, **kwargs)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/variable_scope.py", line 2193, in default_variable_creator
    constraint=constraint)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/variables.py", line 235, in __init__
    constraint=constraint)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/variables.py", line 397, in _init_from_args
    self._snapshot = array_ops.identity(self._variable, name="read")
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/array_ops.py", line 142, in identity
    return gen_array_ops.identity(input, name=name)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/ops/gen_array_ops.py", line 3187, in identity
    "Identity", input=input, name=name)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/framework/op_def_library.py", line 787, in _apply_op_helper
    op_def=op_def)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/framework/ops.py", line 3392, in create_op
    op_def=op_def)
  File "/Users/canapio/tensorflow/lib/python3.6/site-packages/tensorflow/python/framework/ops.py", line 1718, in __init__
    self._traceback = self._graph._extract_stack()  # pylint: disable=protected-access

FailedPreconditionError (see above for traceback): Attempting to use uninitialized value Conv2d_0/weights
	 [[Node: Conv2d_0/weights/read = Identity[T=DT_FLOAT, _device="/job:localhost/replica:0/task:0/device:CPU:0"](Conv2d_0/weights)]]
```


Thank you